### PR TITLE
Fixing to run with CoffeeScript@1.7+

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
 require("coffee-script");
-
+require("coffee-script/register")
 var app = require("./app");
 app.listen(process.env.C9_PORT);


### PR DESCRIPTION
As it was, this error kept prompting:
    `Error: Use CoffeeScript.register() or require the coffee-script/register module to require .coffee.md files.`
That did'nt allow the example to run. "Hello world" text didn't showed up!

GitHub user Maxtaco pointed out the [solution to the error here](https://github.com/maxtaco/coffee-script/issues/138)

Maxtaco:

    "This changed a while back with CoffeeScript@1.7.0.  Check the main Coffee
    page, and here's the explanation:
     - When requiring CoffeeScript files in Node you must now explicitly
     register the compiler. This can be done with require
     'coffee-script/register' ..."